### PR TITLE
Promote long-lived clients and prune rate-limit tables

### DIFF
--- a/src/config_loader.rs
+++ b/src/config_loader.rs
@@ -1,27 +1,29 @@
-use std::collections::HashMap;
-use std::net::{ToSocketAddrs, Ipv4Addr, SocketAddr};
-use std::sync::Mutex;
-use std::fs::File;
-use std::io::{Read, Write};
-use std::time::{SystemTime, UNIX_EPOCH};
+use dashmap::DashMap;
 use lazy_static::lazy_static;
 use log::error;
 use serde::Deserialize;
+use std::collections::HashMap;
+use std::fs::File;
+use std::io::{Read, Write};
+use std::net::{Ipv4Addr, SocketAddr, ToSocketAddrs};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Mutex;
 
 // ---------- Global locks and references ----------
 
 lazy_static! {
     /// For each domain, we store its RedirectionConfig
-    pub static ref REDIRECTION_MAP: Mutex<HashMap<String, RedirectionConfig>> = Mutex::new(HashMap::new());
+    pub static ref REDIRECTION_MAP: DashMap<String, RedirectionConfig> = DashMap::new();
     /// Number of threads to be used by the proxy (set at startup)
     pub static ref PROXY_THREADS: Mutex<usize> = Mutex::new(4);
     /// Bind address for the proxy (loaded from config)
     pub static ref BIND_ADDRESS: Mutex<SocketAddr> = Mutex::new("0.0.0.0:25565".parse().unwrap());
     /// ntfy URL composed from ntfy_server and ntfy_topic in the config.
     pub static ref NTFY_URL: Mutex<String> = Mutex::new(String::new());
-    /// Debug flag read from the config.
-    pub static ref DEBUG: Mutex<bool> = Mutex::new(false);
 }
+
+/// Debug flag read from the config.
+pub static DEBUG: AtomicBool = AtomicBool::new(false);
 
 // ---------- Data structures ----------
 
@@ -119,8 +121,7 @@ pub fn update_proxies_from_config(config_path: &str) {
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
             error!("Config file not found. Creating a default config file...");
             contents = default_config();
-            let mut file =
-                File::create(config_path).expect("Unable to create default config file");
+            let mut file = File::create(config_path).expect("Unable to create default config file");
             file.write_all(contents.as_bytes())
                 .expect("Unable to write default config file");
         }
@@ -129,8 +130,7 @@ pub fn update_proxies_from_config(config_path: &str) {
         }
     }
 
-    let config: Config =
-        serde_yaml::from_str(&contents).expect("Failed to parse YAML config");
+    let config: Config = serde_yaml::from_str(&contents).expect("Failed to parse YAML config");
 
     // 1) Update the bind address
     {
@@ -158,10 +158,7 @@ pub fn update_proxies_from_config(config_path: &str) {
     }
 
     // 4) Update debug flag
-    {
-        let mut debug_flag = DEBUG.lock().unwrap();
-        *debug_flag = config.debug;
-    }
+    DEBUG.store(config.debug, Ordering::Relaxed);
 
     // 5) Parse and store redirections in a map
     let mut new_map = HashMap::new();
@@ -175,16 +172,16 @@ pub fn update_proxies_from_config(config_path: &str) {
                     max_packet_per_second: rd.max_packet_per_second,
                     max_ping_response_per_second: rd.max_ping_response_per_second,
                 };
-                new_map.insert(rd.incoming_domain, rcfg);
+                new_map.insert(rd.incoming_domain.to_ascii_lowercase(), rcfg);
             }
             Err(e) => {
                 error!("Error parsing target '{}': {}", rd.target, e);
             }
         }
     }
-    {
-        let mut map = REDIRECTION_MAP.lock().unwrap();
-        *map = new_map;
+    REDIRECTION_MAP.clear();
+    for (k, v) in new_map {
+        REDIRECTION_MAP.insert(k, v);
     }
 }
 
@@ -195,8 +192,7 @@ pub fn update_proxies() {
 
 /// Resolves a given domain to an `(ip, port)`, plus all other config data.
 pub fn resolve(domain: &str) -> Option<RedirectionConfig> {
-    let map = REDIRECTION_MAP.lock().unwrap();
-    map.get(domain).cloned()
+    REDIRECTION_MAP.get(domain).map(|v| v.clone())
 }
 
 // A default config, just in case the file doesn't exist.
@@ -235,5 +231,6 @@ redirections:
     # Maximum connections per second from a single source. 0 = unlimited
     max_connections_per_second: 5
 
-"#.to_string()
+"#
+    .to_string()
 }

--- a/src/forwarding.rs
+++ b/src/forwarding.rs
@@ -1,22 +1,25 @@
 // ===========================================
 // Imports
 // ===========================================
-use std::collections::HashMap;
-use std::io::{Read, Write};
-use std::net::{IpAddr, Shutdown, TcpStream};
-use std::sync::Mutex;
-use std::time::{SystemTime, UNIX_EPOCH};
+use crate::config_loader::RedirectionConfig;
+use crate::send_ntfy_notification;
+use dashmap::DashMap;
 use lazy_static::lazy_static;
 use log::error;
-use crate::config_loader::{RedirectionConfig, resolve};
-use crate::send_ntfy_notification;
+use std::io::{Read, Write};
+use std::net::{IpAddr, Shutdown, SocketAddr, TcpStream};
+use std::sync::Arc;
+use std::thread;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 // ===========================================
 // Global State: Packet Count Rate Limiting
 // ===========================================
 // (domain, source_ip) -> (timestamp_in_seconds, packet_count_this_second)
 lazy_static! {
-    static ref DOMAIN_SRC_PACKET_COUNT: Mutex<HashMap<(String, IpAddr), (u64, usize)>> = Mutex::new(HashMap::new());
+    static ref DOMAIN_SRC_PACKET_COUNT: DashMap<(String, IpAddr), (u64, usize)> = DashMap::new();
+    // The cleanup thread periodically prunes stale entries so the map's size
+    // tracks only active traffic instead of growing without bound.
 }
 
 // ===========================================
@@ -29,10 +32,13 @@ fn check_packet_limit(domain: &str, src_ip: IpAddr, cfg: &RedirectionConfig) -> 
     if limit == 0 {
         return true; // unlimited
     }
-    let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs();
-    let mut map = DOMAIN_SRC_PACKET_COUNT.lock().unwrap();
-    let entry = map.entry((domain.to_string(), src_ip)).or_insert((now, 0));
-
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    let mut entry = DOMAIN_SRC_PACKET_COUNT
+        .entry((domain.to_string(), src_ip))
+        .or_insert((now, 0));
     if entry.0 == now {
         if entry.1 >= limit {
             return false;
@@ -52,7 +58,9 @@ pub(crate) fn forward_loop(
     mut from: TcpStream,
     mut to: TcpStream,
     domain: String,
+    cfg: Arc<RedirectionConfig>,
     src_ip: IpAddr,
+    src_addr: SocketAddr,
     client_to_server: bool,
     tag: &str,
 ) {
@@ -61,18 +69,16 @@ pub(crate) fn forward_loop(
         match from.read(&mut buf) {
             Ok(n) if n > 0 => {
                 if client_to_server {
-                    if let Some(cfg) = resolve(&domain) {
-                        if !check_packet_limit(&domain, src_ip, &cfg) {
-                            let err_msg = format!(
-                                "Too many packets to domain '{}' from IP '{}' mitigating potential attack, blocking ip for 300 secs", domain, src_ip
-                            );
-                            error!("{}", err_msg);
-                            crate::proxy::block_ip(src_ip);
-                            send_ntfy_notification(&err_msg);
-                            break;
-                        }
+                    if !check_packet_limit(&domain, src_ip, &cfg) {
+                        let err_msg = format!(
+                            "Too many packets to domain '{}' from IP '{}' mitigating potential attack, blocking ip for 300 secs",
+                            domain, src_ip
+                        );
+                        error!("{}", err_msg);
+                        crate::proxy::block_ip(src_ip);
+                        send_ntfy_notification(&err_msg);
+                        break;
                     }
-
                 }
                 if to.write_all(&buf[..n]).is_err() {
                     error!("{} - write error", tag);
@@ -87,4 +93,19 @@ pub(crate) fn forward_loop(
         }
     }
     let _ = to.shutdown(Shutdown::Write);
+    crate::proxy::finish_connection(src_addr);
+}
+
+// Start background cleanup for packet rate-limit map
+pub fn start_packet_cleanup_thread() {
+    thread::spawn(|| loop {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        // Retain counters from the current and previous second so ongoing
+        // traffic isn't disturbed while still pruning old entries.
+        DOMAIN_SRC_PACKET_COUNT.retain(|_, v| v.0 + 1 >= now);
+        thread::sleep(Duration::from_secs(1));
+    });
 }


### PR DESCRIPTION
## Summary
- Promote IPs to a trusted tier after 2 minutes and prioritize them without exceeding per-domain limits
- Periodically prune block lists and rate-limit maps to cap memory usage
- Remove misbehaving IPs from the trusted set
- Document cleanup strategy for rate-limit maps

## Testing
- `cargo test`


------
