### PR TITLE
Align forwarding pool threads with listener

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@
 - **Target Overload Prevention:**  
   Prevents a single target server from being overwhelmed by rate limiting connections per second.
 
-- **Configurable Thread Pool:**  
-  Customize the number of threads used by the proxy (default is 4) for optimal performance.
+- **Configurable Thread Pool:**
+  Customize the number of threads used by the proxy (default is 4) for both listener and forwarding pools.
 
 - **Proxy Protocol v2:**  
   Ensures that your backend servers receive accurate client IP information.
@@ -62,7 +62,7 @@
     # Where should the proxy listen for connections?
     bind-address: "127.0.0.1:25565"
     
-    # Number of threads to use for the proxy (only used at startup)
+    # Number of threads for listener and forwarding pools (only used at startup)
     proxy_threads: 4
    
     # ntfy integration "ntfy.sh" "xy-topic" leave blank if disabled.

--- a/src/config_loader.rs
+++ b/src/config_loader.rs
@@ -201,7 +201,7 @@ fn default_config() -> String {
 # Where should the proxy listen for connections?
 bind-address: "127.0.0.1:25565"
 
-# Number of threads to use for the proxy (only used at startup)
+# Number of threads for listener and forwarding pools (only used at startup)
 proxy_threads: 4
 
 # ntfy integration "ntfy.sh" "xy-topic" leave blank if disabled.

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -65,8 +65,12 @@ lazy_static! {
     static ref ACTIVE_CONNECTIONS: DashMap<SocketAddr, Instant> = DashMap::new();
     // IPs considered trusted (having at least one 2+ minute connection) with last-seen time
     static ref TRUSTED_IPS: DashMap<IpAddr, Instant> = DashMap::new();
-    // A dedicated thread pool for bidirectional forwarding (size adjustable)
-    static ref FORWARDING_POOL: rayon::ThreadPool = ThreadPoolBuilder::new().num_threads(50).build().unwrap();
+    // A dedicated thread pool for bidirectional forwarding
+    // Uses the same thread count as the listener pool (default 4)
+    static ref FORWARDING_POOL: rayon::ThreadPool = ThreadPoolBuilder::new()
+        .num_threads(*PROXY_THREADS.lock().unwrap())
+        .build()
+        .unwrap();
 }
 
 const TRUSTED_IP_IDLE_SECS: u64 = 600;


### PR DESCRIPTION
## Summary
- match forwarding pool thread count with listener pool
- document thread count applies to both listener and forwarding

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a7b2eec99c83318d5a9af634ea3313